### PR TITLE
Update Config for Prod

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,7 +35,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jirastage.mermaidchart.com",
+    "localBaseUrl": "https://jira.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",


### PR DESCRIPTION
This pull request updates the production configuration to use the correct Jira base URL. The change ensures that the application points to the live Jira environment instead of the staging environment.

* Updated the `localBaseUrl` in the `production` section of `config.json` from `https://jirastage.mermaidchart.com` to `https://jira.mermaidchart.com` to reflect the correct production endpoint.