### PR TITLE
updated the install enpoint

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -25,7 +25,7 @@ export default function routes(app, addon) {
     addon,
   });
 
-  app.post('/installed', addon.authenticate(), (req, res) => {
+  app.post('/installed', addon.authenticateInstall(), (req, res) => {
     try {
       if (!addon.settings && !addon.store) {
         console.error('No store available - neither addon.settings nor addon.store exists');


### PR DESCRIPTION
This pull request updates the authentication middleware used for the `/installed` route in `routes/index.js`. The route now uses `addon.authenticateInstall()` instead of `addon.authenticate()`, which is likely more appropriate for installation events. No other changes are included.

* Updated the `/installed` POST route to use `addon.authenticateInstall()` middleware instead of `addon.authenticate()`, improving the correctness of authentication during installation.