### PR TITLE
Updated the baseUrl as vercel domain to test jira ui

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -11,7 +11,7 @@ import {
 import { MermaidChart } from "../utils/MermaidChart.js";
 import log from "../utils/logger.js";
 
-const MC_BASE_URL = process.env.MC_BASE_URL;
+const MC_BASE_URL = "https://collab-git-confluence-ui-figma-mc-prod.vercel.app";
 const MC_CLIENT_ID = process.env.MC_CLIENT_ID;
 
 const diagramsPropertyName = "diagrams";


### PR DESCRIPTION
This pull request makes a small change to the `routes/index.js` file by replacing the `MC_BASE_URL` environment variable with a hardcoded Vercel branch Domain URL. for testing new jira UI
- Hardcoded the `MC_BASE_URL` to `"https://collab-git-confluence-ui-figma-mc-prod.vercel.app"` instead of using the environment variable, for test