### PR TITLE
Update baseurl as vercel domain to test jira UI

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -2,7 +2,7 @@
   "key": "mermaid-chart-app-for-jira",
   "name": "Mermaid Chart for Jira",
   "description": "Official Mermaid Chart App for Jira",
-  "baseUrl": "https://jirastage.mermaidchart.com",
+  "baseUrl": "https://jiratest.mermaidchart.com",
   "vendor": {
     "name": "Mermaid Chart Inc",
     "url": "http://www.mermaidchart.com",

--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
   "stage": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jirastage.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",

--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
   "stage": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jirastage.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -35,7 +35,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jira.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",


### PR DESCRIPTION
This pull request updates environment URLs to point to the Jira test environment instead of the production or staging environments. These changes ensure that the application is configured to use the correct endpoints for testing purposes.

**Environment configuration updates:**

* Changed the `baseUrl` in `atlassian-connect.json` to `https://jiratest.mermaidchart.com` to use the Jira test environment.
* Updated the `localBaseUrl` in the production section of `config.json` to `https://jiratest.mermaidchart.com` for consistency with the test environment.