### PR TITLE
updated the atlassian file and config to support new ai domain

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -2,7 +2,8 @@
   "key": "mermaid-chart-app-for-jira",
   "name": "Mermaid Chart for Jira",
   "description": "Official Mermaid Chart App for Jira",
-  "baseUrl": "https://jiratest.mermaidchart.com",
+  "baseUrl": "https://jiratest.mermaid.ai",
+    "//baseUrl": "{{localBaseUrl}}",
   "vendor": {
     "name": "Mermaid Chart Inc",
     "url": "http://www.mermaidchart.com",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "development": {
     "port": 3000,
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaid.ai",
     "store": {
       "adapter": "sequelize",
       "dialect": "sqlite3",
@@ -13,7 +13,7 @@
   "preview": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaid.ai",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -24,7 +24,7 @@
   "stage": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jirastage.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaid.ai",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -35,7 +35,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jiratest.mermaid.ai",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",


### PR DESCRIPTION
This pull request updates the application's base URLs to use the `mermaid.ai` domain instead of `mermaidchart.com` across multiple environments and configuration files. This ensures consistency and prepares the app for deployment under the new domain.

**Configuration updates:**

* Updated the `baseUrl` in `atlassian-connect.json` to `https://jiratest.mermaid.ai` to reflect the new domain.
* Changed the `localBaseUrl` for all environments (`development`, `preview`, `stage`, `production`) in `config.json` to `https://jiratest.mermaid.ai`. [[1]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL5-R5) [[2]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL16-R16) [[3]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL27-R27) [[4]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL38-R38)