### PR TITLE
updated the mermaid url

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -11,7 +11,7 @@ import {
 import { MermaidChart } from "../utils/MermaidChart.js";
 import log from "../utils/logger.js";
 
-const MC_BASE_URL = "https://collab-git-confluence-ui-figma-mc-prod.vercel.app";
+const MC_BASE_URL = "https://mermaid.ai";
 const MC_CLIENT_ID = process.env.MC_CLIENT_ID;
 
 const diagramsPropertyName = "diagrams";


### PR DESCRIPTION
This pull request updates the `MC_BASE_URL` constant in `routes/index.js` to point to a new service endpoint. This is a small but important change that will affect where requests for Mermaid charts are sent.

* Changed `MC_BASE_URL` from `"https://collab-git-confluence-ui-figma-mc-prod.vercel.app"` to `"https://mermaid.ai"` in `routes/index.js` to use the new Mermaid chart service endpoint.