### PR TITLE
Revert "updated the atlassian file and config to support new ai domain"

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -2,8 +2,7 @@
   "key": "mermaid-chart-app-for-jira",
   "name": "Mermaid Chart for Jira",
   "description": "Official Mermaid Chart App for Jira",
-  "baseUrl": "https://jiratest.mermaid.ai",
-    "//baseUrl": "{{localBaseUrl}}",
+  "baseUrl": "https://jiratest.mermaidchart.com",
   "vendor": {
     "name": "Mermaid Chart Inc",
     "url": "http://www.mermaidchart.com",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "development": {
     "port": 3000,
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaid.ai",
+    "localBaseUrl": "https://jiratest.mermaidchart.com",
     "store": {
       "adapter": "sequelize",
       "dialect": "sqlite3",
@@ -13,7 +13,7 @@
   "preview": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaid.ai",
+    "localBaseUrl": "https://jiratest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -24,7 +24,7 @@
   "stage": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaid.ai",
+    "localBaseUrl": "https://jirastage.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -35,7 +35,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaid.ai",
+    "localBaseUrl": "https://jiratest.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",


### PR DESCRIPTION
Reverts Mermaid-Chart/jira-plugin#35
This pull request updates the base URLs for the application in both the Atlassian Connect descriptor and environment-specific configuration files. The main goal is to move from the new `mermaid.ai` domain to the old `mermaidchart.com` domain across all environments as it was for test .

**Configuration and environment updates:**

* Updated the `baseUrl` in `atlassian-connect.json` to use `https://jiratest.mermaidchart.com` instead of the old `mermaid.ai` domain.
* Changed the `localBaseUrl` for all environments (`development`, `preview`, `production`) in `config.json` from `https://jiratest.mermaid.ai` to `https://jiratest.mermaidchart.com`. [[1]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL5-R5) [[2]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL16-R16) [[3]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL38-R38)
* Updated the `localBaseUrl` for the `stage` environment in `config.json` to use `https://jirastage.mermaidchart.com`.