### PR TITLE
Updated jira plugin to support fullscreen and add pluginSource in the…

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -50,8 +50,8 @@
       {
         "url": "/editor",
         "options": {
-          "width": "95%",
-          "height": "67%",
+          "width": "100%",
+          "height": "100%",
           "header": {
             "value": "Mermaid Chart"
           }
@@ -61,8 +61,8 @@
       {
         "url": "/select",
         "options": {
-          "width": "95%",
-          "height": "67%",
+          "width": "100%",
+          "height": "100%",
           "header": {
             "value": "Mermaid Chart"
           }
@@ -72,8 +72,8 @@
       {
         "url": "/viewer",
         "options": {
-          "width": "95%",
-          "height": "67%",
+          "width": "100%",
+          "height": "100%",
           "header": {
             "value": "Mermaid Chart"
           }

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,64 @@
+app:
+  id: ari:cloud:ecosystem::app/25544ca3-4108-4945-ae1e-f6b02045979b
+  connect:
+    key: mermaid-chart-app-for-jira
+    remote: connect
+    authentication: jwt
+  runtime:
+    name: nodejs20.x
+remotes:
+  - key: connect
+    baseUrl: https://jiratest.mermaidchart.com
+connectModules:
+  jira:lifecycle:
+    - key: lifecycle-events
+      installed: /installed
+  jira:jiraIssueContents:
+    - icon:
+        width: 80
+        height: 80
+        url: /icon_80x80.png
+      target:
+        type: web_panel
+        url: /issue-content?issueKey={issue.key}
+      tooltip:
+        value: ''
+      jiraNativeAppsEnabled: false
+      name:
+        value: Mermaid Chart
+      key: jira-issue-content
+  jira:dialogs:
+    - url: /editor
+      options:
+        width: 100%
+        height: 100%
+        header:
+          value: Mermaid Chart
+      key: dialog-module-edit
+    - url: /select
+      options:
+        width: 100%
+        height: 100%
+        header:
+          value: Mermaid Chart
+      key: dialog-module-select
+    - url: /viewer
+      options:
+        width: 100%
+        height: 100%
+        header:
+          value: Mermaid Chart
+      key: dialog-module-view
+    - url: /alert
+      options:
+        height: 200px
+        width: 300px
+        header:
+          value: Mermaid Chart Alert
+      key: dialog-module-alert
+permissions:
+  scopes:
+    - read:connect-jira
+    - write:connect-jira
+    - delete:connect-jira
+    - act-as-user:connect-jira

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -1,9 +1,5 @@
 #editor-content {
-  height: 100vh;
-  width: 100vw;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
+  height: 100%;
 }
 
 .error {

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -1,5 +1,9 @@
 #editor-content {
-  height: 100%;
+  height: 100vh;
+  width: 100vw;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 .error {

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -41,6 +41,9 @@ function App() {
           AP.dialog.close({ chart: e.data.data, replace: true });
           break;
       }
+      if (e.data.type === "mermaid-chart-jira-back" && action === "navigateBack") {
+        AP.dialog.close();
+      }
     };
   }, []);
 
@@ -61,7 +64,7 @@ function App() {
   };
 
   const iframeURL = buildUrl(
-    `/app/projects/${image.projectID}/diagrams/${image.documentID}/version/v.${image.major}.${image.minor}/edit`
+      `/app/projects/${image.projectID}/diagrams/${image.documentID}/version/v${image.major}.${image.minor}/edit?pluginSource=jira`
   );
 
   if (iframeURL) {

--- a/public/js/issue-content.js
+++ b/public/js/issue-content.js
@@ -68,7 +68,7 @@ function App() {
   const viewDiagramClick = (chart) => {
     AP.dialog.create({
       key: "dialog-module-view",
-      chrome: true,
+      chrome: false,
       customData: {
         image: chart,
         baseUrl: MC_BASE_URL,
@@ -85,7 +85,7 @@ function App() {
 
     AP.dialog.create({
       key: "dialog-module-edit",
-      chrome: true,
+      chrome: false,
       customData: {
         image,
         baseUrl: MC_BASE_URL,
@@ -102,7 +102,7 @@ function App() {
 
     AP.dialog.create({
       key: "dialog-module-select",
-      chrome: true,
+      chrome: false,
       customData: {
         baseUrl: MC_BASE_URL,
         accessToken: accessToken,

--- a/public/js/select.js
+++ b/public/js/select.js
@@ -40,6 +40,9 @@ function App() {
 
           break;
       }
+        if (e.data.type === "mermaid-chart-jira-back" && action === "navigateBack") {
+        AP.dialog.close();
+      }
     };
   }, []);
   // if (!accessToken) {
@@ -64,7 +67,7 @@ function App() {
   //   `/app/projects/${document.projectID}/diagrams/${document.documentID}/version/v.${document.major}.${document.minor}/edit`
   // );
 
-  const iframeURL = buildUrl(`/app/plugins/confluence/select`);
+  const iframeURL = buildUrl(`/app/plugins/confluence/select?pluginSource=jira`);
   console.log("buildUrl:", iframeURL);
   // log.info("buildUrl: ", iframeURL);
 


### PR DESCRIPTION
This pull request introduces several UI and integration improvements to the editor and dialog modules, primarily to enhance the Jira plugin experience and streamline dialog presentation. The most important changes are grouped below:

**Jira Plugin Integration:**

* Updated iframe URLs in both `public/js/editor.js` and `public/js/select.js` to include the `pluginSource=jira` query parameter, ensuring the correct context is passed when editing or selecting diagrams from Jira. [[1]](diffhunk://#diff-87373dd7bf5de920d0a60f6971903dbf23564c110d39698d0be0562f1169894aL64-R67) [[2]](diffhunk://#diff-83ffda297953d3e3e36416f07e7762b5a3ef8a7e3628fdd0a9b8c9dcd3846441L67-R70)

**Dialog Presentation:**

* Set the `chrome` option to `false` for all dialog creations in `public/js/issue-content.js`, resulting in dialogs without the default Atlassian chrome for a cleaner, more integrated look. [[1]](diffhunk://#diff-9962f835981fd1a9c6bb2ae6ca742f3fe0d8ea36f143c5225d3c4e66cb1f7617L71-R71) [[2]](diffhunk://#diff-9962f835981fd1a9c6bb2ae6ca742f3fe0d8ea36f143c5225d3c4e66cb1f7617L88-R88) [[3]](diffhunk://#diff-9962f835981fd1a9c6bb2ae6ca742f3fe0d8ea36f143c5225d3c4e66cb1f7617L105-R105)

**Navigation Handling:**

* Added support for the `"mermaid-chart-jira-back"` message type with `"navigateBack"` action in both `public/js/editor.js` and `public/js/select.js`, allowing dialogs to be closed programmatically when navigating back from Jira. [[1]](diffhunk://#diff-87373dd7bf5de920d0a60f6971903dbf23564c110d39698d0be0562f1169894aR44-R46) [[2]](diffhunk://#diff-83ffda297953d3e3e36416f07e7762b5a3ef8a7e3628fdd0a9b8c9dcd3846441R43-R45)

**Editor Layout Enhancement:**

* Modified the `#editor-content` CSS in `public/css/editor.css` to use full viewport dimensions (`100vw` and `100vh`), removed default margin and padding, and set `overflow: hidden` for a more immersive editor experience.