### PR TITLE
Update the baseUrl for stage

### DIFF
--- a/atlassian-connect.json
+++ b/atlassian-connect.json
@@ -2,7 +2,7 @@
   "key": "mermaid-chart-app-for-jira",
   "name": "Mermaid Chart for Jira",
   "description": "Official Mermaid Chart App for Jira",
-  "baseUrl": "https://jiratest.mermaidchart.com",
+  "baseUrl": "https://jirastage.mermaidchart.com",
   "vendor": {
     "name": "Mermaid Chart Inc",
     "url": "http://www.mermaidchart.com",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "development": {
     "port": 3000,
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jirastage.mermaidchart.com",
     "store": {
       "adapter": "sequelize",
       "dialect": "sqlite3",
@@ -13,7 +13,7 @@
   "preview": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jirastage.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",
@@ -35,7 +35,7 @@
   "production": {
     "port": "$PORT",
     "errorTemplate": true,
-    "localBaseUrl": "https://jiratest.mermaidchart.com",
+    "localBaseUrl": "https://jirastage.mermaidchart.com",
     "allowedBaseUrls": ["$VERCEL_BRANCH_URL"],
     "store": {
       "adapter": "@upstash/redis",

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ app:
     name: nodejs20.x
 remotes:
   - key: connect
-    baseUrl: https://jiratest.mermaidchart.com
+    baseUrl: https://jirastage.mermaidchart.com
 connectModules:
   jira:lifecycle:
     - key: lifecycle-events


### PR DESCRIPTION
This pull request updates environment configuration to point from the `jiratest.mermaidchart.com` domain to the new `jirastage.mermaidchart.com` domain. This affects all environments, ensuring that the application and its integrations use the new staging base URL consistently.

**Configuration updates:**

* Updated the `baseUrl` in `atlassian-connect.json` to use `https://jirastage.mermaidchart.com` instead of `https://jiratest.mermaidchart.com`.
* Changed the `localBaseUrl` for the `development`, `preview`, and `production` environments in `config.json` to use the new staging URL. [[1]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL5-R5) [[2]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL16-R16) [[3]](diffhunk://#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cfL38-R38)
* Updated the `baseUrl` in the `manifest.yml` under the `remotes` section to point to `https://jirastage.mermaidchart.com`.